### PR TITLE
Enable the InputButton's href prop to take a next UrlObject

### DIFF
--- a/src/InputButton/InputButton.tsx
+++ b/src/InputButton/InputButton.tsx
@@ -60,11 +60,11 @@ type TInputButtonBase = {
   children: ReactElement<TText | TIcon | TKeyValuePair>
 }
 
-type TNextLink = LinkProps["href"]
+type TNextLinkHref = LinkProps["href"]
 
 type TInputButtonVariantLink = TInputButtonBase & {
   variant: EInputButtonVariant.Link
-  href?: TNextLink
+  href?: TNextLinkHref
 }
 
 type TInputButtonVariantOthers = TInputButtonBase & {

--- a/src/InputButton/InputButton.tsx
+++ b/src/InputButton/InputButton.tsx
@@ -62,7 +62,7 @@ type TInputButtonBase = {
 
 type TInputButtonVariantLink = TInputButtonBase & {
   variant: EInputButtonVariant.Link
-  href?: LinkProps["href"]
+  href?: Pick<LinkProps, "href">
 }
 
 type TInputButtonVariantOthers = TInputButtonBase & {

--- a/src/InputButton/InputButton.tsx
+++ b/src/InputButton/InputButton.tsx
@@ -60,9 +60,11 @@ type TInputButtonBase = {
   children: ReactElement<TText | TIcon | TKeyValuePair>
 }
 
+type TNextLink = LinkProps["href"]
+
 type TInputButtonVariantLink = TInputButtonBase & {
   variant: EInputButtonVariant.Link
-  href?: Pick<LinkProps, "href">
+  href?: TNextLink
 }
 
 type TInputButtonVariantOthers = TInputButtonBase & {

--- a/src/InputButton/InputButton.tsx
+++ b/src/InputButton/InputButton.tsx
@@ -9,6 +9,7 @@ import { Composition } from "@new/Composition/Composition"
 import { BackgroundCard } from "@new/Composition/BackgroundCard"
 import { LayoutInputButton } from "./LayoutInputButton"
 import Link from "next/link"
+import { LinkProps } from "next/dist/client/link";
 
 const Output = styled.output<Pick<TInputButton, "loading" | "variant">>(p => ({
   display: "flex",
@@ -62,7 +63,7 @@ type TInputButtonBase = {
 
 type TInputButtonVariantLink = TInputButtonBase & {
   variant: EInputButtonVariant.Link
-  href?: string
+  href?: LinkProps["href"]
 }
 
 type TInputButtonVariantOthers = TInputButtonBase & {

--- a/src/InputButton/InputButton.tsx
+++ b/src/InputButton/InputButton.tsx
@@ -8,8 +8,7 @@ import { TKeyValuePair } from "@new/KeyValuePair/KeyValuePair"
 import { Composition } from "@new/Composition/Composition"
 import { BackgroundCard } from "@new/Composition/BackgroundCard"
 import { LayoutInputButton } from "./LayoutInputButton"
-import Link from "next/link"
-import { LinkProps } from "next/dist/client/link";
+import Link, { LinkProps } from "next/link"
 
 const Output = styled.output<Pick<TInputButton, "loading" | "variant">>(p => ({
   display: "flex",


### PR DESCRIPTION
href now takes string like before or an object of this interface
```
interface UrlObject {
    auth?: string | null | undefined;
    hash?: string | null | undefined;
    host?: string | null | undefined;
    hostname?: string | null | undefined;
    href?: string | null | undefined;
    pathname?: string | null | undefined;
    protocol?: string | null | undefined;
    search?: string | null | undefined;
    slashes?: boolean | null | undefined;
    port?: string | number | null | undefined;
    query?: string | null | ParsedUrlQueryInput | undefined;
}
```
this should allow doing e.g. this
```
<InputButton
  href={{
    pathname: SITE_LINKS.COMPANY_MANAGER.COLLECT.PERFORMANCE.TOPICS(framework.id),
    query: {
      ...query,
      performanceFilterYear: paf.assignment.reportingYear,
      performanceFilterMonth: paf.assignment.reportingMonth,
    },
  }}
  {...}
>
  {...}
</InputButton>
```