### PR TITLE
Fix label for combobox

### DIFF
--- a/src/InputCombobox/InputCombobox.tsx
+++ b/src/InputCombobox/InputCombobox.tsx
@@ -163,7 +163,7 @@ export const InputCombobox = forwardRef<HTMLDivElement, PropsWithChildren<TInput
 
       return selectedItems.length > 0 ? label : textNoSelection
     } else {
-      return items.findLast(item => (item.value as string).toLowerCase() === value)?.label || textNoSelection
+      return items.findLast(item => (item.value as string) === value)?.label || textNoSelection
     }
   }
 


### PR DESCRIPTION
When the combobox is closed, it defaults despite a selection being present, if that selection contains upper-case characters.