### PR TITLE
Make offset prop-able in Takeover component

### DIFF
--- a/src/Takeover/Takeover.tsx
+++ b/src/Takeover/Takeover.tsx
@@ -10,32 +10,40 @@ import styled from "@emotion/styled"
 import { Spacer } from "@new/Spacer/Spacer"
 import { TText } from "@new/Text/Text"
 
-const offsetTop = "64px"
-const offsetLeft = "76px"
-const offsetLeftSmall = "40px"
+const defaultOffsetTop = "64px"
+const defaultOffsetLeft = "76px"
+const defaultOffsetLeftSmall = "40px"
+
+interface RadixDialogContentProps {
+  offsetTop: string
+  offsetLeft: string
+  offsetLeftSmall: string
+}
+
+const RadixDialogContent = styled(RadixDialog.Content)<RadixDialogContentProps>(
+  ({ offsetTop, offsetLeft, offsetLeftSmall }) => ({
+    display: "flex",
+    position: "fixed",
+    top: offsetTop,
+    left: offsetLeft,
+    width: `calc(100vw - ${offsetLeft})`,
+    height: `calc(100vh - ${offsetTop})`,
+    zIndex: 1,
+    maxHeight: `calc(100vh - ${offsetTop})`,
+    overflowY: "auto",
+    backgroundColor: "red",
+
+    "@media (max-width: 900px)": {
+      left: offsetLeftSmall,
+      width: `calc(100vw - ${offsetLeftSmall})`,
+    },
+  }),
+)
 
 const RadixDialogClose = styled(RadixDialog.Close)({
   display: "flex",
   transform: "translateX(var(--BU))",
   height: "fit-content",
-})
-
-const RadixDialogContent = styled(RadixDialog.Content)({
-  display: "flex",
-  position: "fixed",
-  top: offsetTop,
-  left: offsetLeft,
-  width: `calc(100vw - ${offsetLeft})`,
-  height: `calc(100vh - ${offsetTop})`,
-  zIndex: 1,
-  maxHeight: `calc(100vh - ${offsetTop})`,
-  overflowY: "auto",
-  backgroundColor: "red",
-
-  "@media (max-width: 900px)": {
-    left: offsetLeftSmall,
-    width: `calc(100vw - ${offsetLeftSmall})`,
-  },
 })
 
 export type TTakeover = {
@@ -48,6 +56,9 @@ export type TTakeover = {
   buttonPrimary?: ReactElement<TInputButton>
   buttonSecondary?: ReactElement<TInputButton>
   buttonTertiary?: ReactElement<TInputButton>
+  offsetTop?: string
+  offsetLeft?: string
+  offsetLeftSmall?: string
 }
 
 export const Takeover = ({
@@ -60,6 +71,9 @@ export const Takeover = ({
   buttonPrimary,
   buttonSecondary,
   buttonTertiary,
+  offsetTop = defaultOffsetTop,
+  offsetLeft = defaultOffsetLeft,
+  offsetLeftSmall = defaultOffsetLeftSmall,
 }: TTakeover) => {
   useEffect(() => {
     if (open) {
@@ -76,7 +90,7 @@ export const Takeover = ({
   return (
     <RadixDialog.Root open={open} onOpenChange={onOpenChange} modal={false}>
       <RadixDialog.Portal>
-        <RadixDialogContent>
+        <RadixDialogContent offsetTop={offsetTop} offsetLeft={offsetLeft} offsetLeftSmall={offsetLeftSmall}>
           <Composition explodeHeight>
             <BackgroundCard colorBackground={[EColor.White]} />
 

--- a/src/Takeover/Takeover.tsx
+++ b/src/Takeover/Takeover.tsx
@@ -10,9 +10,9 @@ import styled from "@emotion/styled"
 import { Spacer } from "@new/Spacer/Spacer"
 import { TText } from "@new/Text/Text"
 
-const defaultOffsetTop = "64px"
-const defaultOffsetLeft = "76px"
-const defaultOffsetLeftSmall = "40px"
+const offsetTop = "64px"
+const offsetLeft = "76px"
+const offsetLeftSmall = "40px"
 
 const RadixDialogContent = styled(RadixDialog.Content)<
   Pick<TTakeover, "offsetTopOverride" | "offsetLeftOverride" | "offsetLeftSmallOverride">
@@ -65,9 +65,9 @@ export const Takeover = ({
   buttonPrimary,
   buttonSecondary,
   buttonTertiary,
-  offsetTopOverride = defaultOffsetTop,
-  offsetLeftOverride = defaultOffsetLeft,
-  offsetLeftSmallOverride = defaultOffsetLeftSmall,
+  offsetTopOverride = offsetTop,
+  offsetLeftOverride = offsetLeft,
+  offsetLeftSmallOverride = offsetLeftSmall,
 }: TTakeover) => {
   useEffect(() => {
     if (open) {

--- a/src/Takeover/Takeover.tsx
+++ b/src/Takeover/Takeover.tsx
@@ -14,31 +14,25 @@ const defaultOffsetTop = "64px"
 const defaultOffsetLeft = "76px"
 const defaultOffsetLeftSmall = "40px"
 
-interface RadixDialogContentProps {
-  offsetTop: string
-  offsetLeft: string
-  offsetLeftSmall: string
-}
+const RadixDialogContent = styled(RadixDialog.Content)<
+  Pick<TTakeover, "offsetTopOverride" | "offsetLeftOverride" | "offsetLeftSmallOverride">
+>(p => ({
+  display: "flex",
+  position: "fixed",
+  top: p.offsetTopOverride,
+  left: p.offsetLeftOverride,
+  width: `calc(100vw - ${p.offsetTopOverride})`,
+  height: `calc(100vh - ${p.offsetTopOverride})`,
+  zIndex: 1,
+  maxHeight: `calc(100vh - ${p.offsetTopOverride})`,
+  overflowY: "auto",
+  backgroundColor: "red",
 
-const RadixDialogContent = styled(RadixDialog.Content)<RadixDialogContentProps>(
-  ({ offsetTop, offsetLeft, offsetLeftSmall }) => ({
-    display: "flex",
-    position: "fixed",
-    top: offsetTop,
-    left: offsetLeft,
-    width: `calc(100vw - ${offsetLeft})`,
-    height: `calc(100vh - ${offsetTop})`,
-    zIndex: 1,
-    maxHeight: `calc(100vh - ${offsetTop})`,
-    overflowY: "auto",
-    backgroundColor: "red",
-
-    "@media (max-width: 900px)": {
-      left: offsetLeftSmall,
-      width: `calc(100vw - ${offsetLeftSmall})`,
-    },
-  }),
-)
+  "@media (max-width: 900px)": {
+    left: p.offsetLeftSmallOverride,
+    width: `calc(100vw - ${p.offsetLeftSmallOverride})`,
+  },
+}))
 
 const RadixDialogClose = styled(RadixDialog.Close)({
   display: "flex",
@@ -56,9 +50,9 @@ export type TTakeover = {
   buttonPrimary?: ReactElement<TInputButton>
   buttonSecondary?: ReactElement<TInputButton>
   buttonTertiary?: ReactElement<TInputButton>
-  offsetTop?: string
-  offsetLeft?: string
-  offsetLeftSmall?: string
+  offsetTopOverride?: string
+  offsetLeftOverride?: string
+  offsetLeftSmallOverride?: string
 }
 
 export const Takeover = ({
@@ -71,9 +65,9 @@ export const Takeover = ({
   buttonPrimary,
   buttonSecondary,
   buttonTertiary,
-  offsetTop = defaultOffsetTop,
-  offsetLeft = defaultOffsetLeft,
-  offsetLeftSmall = defaultOffsetLeftSmall,
+  offsetTopOverride = defaultOffsetTop,
+  offsetLeftOverride = defaultOffsetLeft,
+  offsetLeftSmallOverride = defaultOffsetLeftSmall,
 }: TTakeover) => {
   useEffect(() => {
     if (open) {
@@ -90,7 +84,11 @@ export const Takeover = ({
   return (
     <RadixDialog.Root open={open} onOpenChange={onOpenChange} modal={false}>
       <RadixDialog.Portal>
-        <RadixDialogContent offsetTop={offsetTop} offsetLeft={offsetLeft} offsetLeftSmall={offsetLeftSmall}>
+        <RadixDialogContent
+          offsetTopOverride={offsetTopOverride}
+          offsetLeftOverride={offsetLeftOverride}
+          offsetLeftSmallOverride={offsetLeftSmallOverride}
+        >
           <Composition explodeHeight>
             <BackgroundCard colorBackground={[EColor.White]} />
 


### PR DESCRIPTION
This PR introduces overrides to Takeover positioning (temporary, and for use with the new navigation). Will get revisited.