### PR TITLE
Elevate bottom padding for takeover chin to avoid intercom chat being blocked

### DIFF
--- a/src/Takeover/internal/LayoutTakeover.tsx
+++ b/src/Takeover/internal/LayoutTakeover.tsx
@@ -42,7 +42,7 @@ const ContentMiddle = styled.div({
 const ContentEnd = styled.div({
   display: "flex",
   flexDirection: "row",
-  padding: "calc(var(--BU) * 4)",
+  padding: "calc(var(--BU) * 4) calc(var(--BU) * 4) calc(var(--BU) * 24) calc(var(--BU) * 4)",
   borderTop: `solid 1px ${computeColor([EColor.Black, 100])}`,
   justifyContent: "flex-end",
   alignItems: "center",


### PR DESCRIPTION
Problem on production making customization useless (see bottom right corner):

![image](https://github.com/user-attachments/assets/c75fd35f-eca9-49c5-a07e-1add1ddd0136)

I suggest lifting the chin:

![chin_lifted](https://github.com/user-attachments/assets/1ecb62e8-b1c4-4c00-b283-f8d7c83da768)

Carlo has been made aware. Until design comes with a proposal, let's at least make the feature possible to use.