### PR TITLE
Allow TColor on Switch instead of EColor

### DIFF
--- a/src/Switch/Switch.tsx
+++ b/src/Switch/Switch.tsx
@@ -1,7 +1,7 @@
 import { ReactElement, useId } from "react"
 import * as RadixSwitch from "@radix-ui/react-switch"
 import styled from "@emotion/styled"
-import { computeColor, EColor } from "@new/Color"
+import { computeColor, TColor } from "@new/Color"
 import { TText } from "@new/Text/Text"
 import { KeyValuePair } from "@new/KeyValuePair/KeyValuePair"
 import { EDirection } from "@new/EDirection"
@@ -22,7 +22,7 @@ const SwitchRoot = styled(RadixSwitch.Root)<Pick<TSwitch, "colorBackground" | "c
   width: "calc(var(--BU) * 8)",
   height: "calc(var(--BU) * 5)",
   border: 0,
-  backgroundColor: computeColor([p.colorBackground, 700]),
+  backgroundColor: computeColor(p.colorBackground),
   borderRadius: "9999px",
   cursor: "pointer",
 
@@ -31,7 +31,7 @@ const SwitchRoot = styled(RadixSwitch.Root)<Pick<TSwitch, "colorBackground" | "c
   },
 
   "&[data-state='checked']": {
-    backgroundColor: computeColor([p.colorValueTrue, 700]),
+    backgroundColor: computeColor(p.colorValueTrue),
   },
 }))
 
@@ -39,7 +39,7 @@ const SwitchThumb = styled(RadixSwitch.Thumb)<Pick<TSwitch, "colorForeground">>(
   display: "flex",
   width: "calc(var(--BU) * 5 - 2px)",
   height: "calc(var(--BU) * 5 - 2px)",
-  backgroundColor: computeColor([p.colorForeground, 700]),
+  backgroundColor: computeColor(p.colorForeground),
   borderRadius: "9999px",
   transition: "transform 100ms",
   transform: "translateX(1px) translateY(1px)",
@@ -59,9 +59,9 @@ const Label = styled.label({
 export type TSwitch = TPlaywright & {
   value: boolean
   onChange: (value: boolean) => void
-  colorBackground: EColor
-  colorForeground: EColor
-  colorValueTrue: EColor
+  colorBackground: TColor
+  colorForeground: TColor
+  colorValueTrue: TColor
   label?: ReactElement<TText>
 }
 


### PR DESCRIPTION
Without ability to define lightness and only a limited colorset available, current usage looks not great.

Only kind of useful false state color is hard black. 

With this change it'll become a bit more flexible.

Current usage (disabled state):
![image](https://github.com/user-attachments/assets/fc39c53e-9ad8-4c90-bd8e-50a373f1ef0f)

With ability to define lightness (disabled state):
![image](https://github.com/user-attachments/assets/51cd6078-a7fe-40d0-b199-9a4616a07c3e)
