### PR TITLE
fix(Switch): lower default lightness for background

### DIFF
--- a/src/Switch/Switch.tsx
+++ b/src/Switch/Switch.tsx
@@ -22,7 +22,7 @@ const SwitchRoot = styled(RadixSwitch.Root)<Pick<TSwitch, "colorBackground" | "c
   width: "calc(var(--BU) * 8)",
   height: "calc(var(--BU) * 5)",
   border: 0,
-  backgroundColor: computeColor([p.colorBackground, 700]),
+  backgroundColor: computeColor([p.colorBackground, 100]),
   borderRadius: "9999px",
   cursor: "pointer",
 


### PR DESCRIPTION
Aligned with Carlo. Design not planning to use in grey background contexts, so lowering lightness on background color.

Before:
![image](https://github.com/user-attachments/assets/03f06c35-fc86-4fb8-a629-65214d7e6b93)

After:
![image](https://github.com/user-attachments/assets/4a5876cc-528d-4cc7-8c1e-c044bcc5c76d)
