### PR TITLE
Always have 24px space between tab header and tab content

### DIFF
--- a/src/Tabs/TabsContentItem.tsx
+++ b/src/Tabs/TabsContentItem.tsx
@@ -26,7 +26,7 @@ export const TabsContentItem = forwardRef<
       asChild
     >
       <>
-        <Spacer size={ESize.Small} />
+        <Spacer size={ESize.Large} />
 
         {children}
       </>


### PR DESCRIPTION
Aligned with Carlo. All tabs must have 24px between tab header and content.

Upgrading this in the UI project will need to go through all usages and remove potential self-added spacers. (I've seen a few already)