### PR TITLE
Possibility to set the active value of a tab

### DIFF
--- a/src/Tabs/Tabs.tsx
+++ b/src/Tabs/Tabs.tsx
@@ -19,14 +19,21 @@ const List = styled(RadixTabs.List)({
 })
 
 export type TTabs = TPlaywright & {
+  contentTargetId?: string
   defaultContentTargetId: string
   navigationItems: ReactElement<TTabsNavigationItem> | ReactElement<TTabsNavigationItem>[]
   contentItems: ReactElement<TTabsContentItem> | ReactElement<TTabsContentItem>[]
 }
 
-export const Tabs = ({ defaultContentTargetId, navigationItems, contentItems, playwrightTestId }: TTabs) => {
+export const Tabs = ({
+  contentTargetId,
+  defaultContentTargetId,
+  navigationItems,
+  contentItems,
+  playwrightTestId,
+}: TTabs) => {
   return (
-    <Root defaultValue={defaultContentTargetId} data-playwright-testid={playwrightTestId}>
+    <Root value={contentTargetId} defaultValue={defaultContentTargetId} data-playwright-testid={playwrightTestId}>
       <List>{navigationItems}</List>
 
       {contentItems}


### PR DESCRIPTION
Enables possibility to change from inside tab content. We need that in certain user flows. Aligned with Carlo.

My considerations is making this optional. We don't want to enforce the use of this, but only enable the possibility.

For instance on this overview page, where each card should take a user to a different tab:
![image](https://github.com/user-attachments/assets/eb3759b0-3f3b-4f03-bc6f-6b3bfc530fac)
