### PR TITLE
Introduce fixedKeyFieldPosition on DataTable

### DIFF
--- a/src/DataTable/DataTable.tsx
+++ b/src/DataTable/DataTable.tsx
@@ -249,11 +249,12 @@ export type DataTableProps = {
   mode: "simple" | "filter" | "edit"
   data: any[]
   columns: Column[]
-  defaultSortColumn: string
+  defaultSortColumn?: string
   defaultSortDirection?: SortDirection
   rowKeyField: string
   exportName: string
   fixedKeyField?: string
+  fixedKeyFieldPosition?: "left" | "right"
   selectKeyField?: string
   selectDisabledField?: string
   virtualScrolling?: boolean
@@ -871,7 +872,8 @@ export const DataTable = (p: DataTableProps) => {
                     elementAttributes: headCellElementAttributes => {
                       if (p.fixedKeyField === headCellElementAttributes.column.key) {
                         return {
-                          className: "override-ka-fixed-left",
+                          className:
+                            p.fixedKeyFieldPosition === "right" ? "override-ka-fixed-right" : "override-ka-fixed-left",
                         }
                       }
                     },
@@ -1038,13 +1040,15 @@ export const DataTable = (p: DataTableProps) => {
                     elementAttributes: cellElementAttributes => {
                       if (p.fixedKeyField === cellElementAttributes.column.key) {
                         return {
-                          className: "override-ka-fixed-left",
+                          className:
+                            p.fixedKeyFieldPosition === "right" ? "override-ka-fixed-right" : "override-ka-fixed-left",
                         }
                       }
 
                       if (p.fixedKeyField && cellElementAttributes.column.key === KEY_ACTIONS) {
                         return {
-                          className: "override-ka-fixed-right",
+                          className:
+                            p.fixedKeyFieldPosition === "right" ? "override-ka-fixed-right" : "override-ka-fixed-left",
                         }
                       }
                     },


### PR DESCRIPTION
To allow fixing column on left or right hand side of table.

Default stays being "left" so the change is backwards compatible.

Use case:
![image](https://github.com/user-attachments/assets/f0202c02-958e-4d4b-8693-d0cdeab349ff)