### PR TITLE
Fix broken ACTIONS column on DataTable in "edit" mode

### DIFF
--- a/src/DataTable/DataTable.tsx
+++ b/src/DataTable/DataTable.tsx
@@ -1052,8 +1052,7 @@ export const DataTable = (p: DataTableProps) => {
 
                       if (p.fixedKeyField && cellElementAttributes.column.key === KEY_ACTIONS) {
                         return {
-                          className:
-                            p.fixedKeyFieldPosition === "right" ? "override-ka-fixed-right" : "override-ka-fixed-left",
+                          className: "override-ka-fixed-right",
                         }
                       }
                     },

--- a/src/DataTable/DataTable.tsx
+++ b/src/DataTable/DataTable.tsx
@@ -249,7 +249,7 @@ export type DataTableProps = {
   mode: "simple" | "filter" | "edit"
   data: any[]
   columns: Column[]
-  defaultSortColumn?: string
+  defaultSortColumn: string
   defaultSortDirection?: SortDirection
   rowKeyField: string
   exportName: string


### PR DESCRIPTION
In DataTable "edit" mode there are row actions displayed in a fixed column on the right hand side of a table. I accidentally broke this with my last release. Ensure that the classname is properly set for that scenario now.

Plus make defaultSortOrder required again, based on feedback from Thomas.