### PR TITLE
Make link color lightness 700 no matter of text lightness

### DIFF
--- a/src/Text/Text.tsx
+++ b/src/Text/Text.tsx
@@ -71,7 +71,7 @@ const Container = styled.p<Omit<TextProps, "fill"> & { _fill: TextProps["fill"] 
   },
 
   "& a": {
-    color: computeColor([Color.Quarternary, p._fill?.[1] || 700]),
+    color: computeColor([Color.Quarternary, 700]),
   },
 
   "& abbr": {


### PR DESCRIPTION
Because we allowed the link lightness to depend on the Text component lightness, we had cases like this: 
![image](https://github.com/user-attachments/assets/32eb1302-4d27-47c5-ae00-d8e0acab0e52)

This PR changes the link lightness inside Text to always be 700