### PR TITLE
PROD-3943: Bugfix/InputCombobox case-sensitive selection

### DIFF
--- a/src/InputCombobox/InputCombobox.tsx
+++ b/src/InputCombobox/InputCombobox.tsx
@@ -215,7 +215,7 @@ export const InputCombobox = forwardRef<HTMLDivElement, PropsWithChildren<InputC
     const onSelectSingle = (value: string) => {
       setOpen(false)
 
-      const item = Object.values(items).findLast(item => item.label.toLowerCase() === value.trim().toLowerCase())
+      const item = Object.values(items).findLast(item => item.label === value.trim())
 
       if (item) {
         p.onChange(item.value)


### PR DESCRIPTION
This PR fixes an issue in the InputCombobox component where unit types with different case (e.g., "MJ" vs "mJ") were being treated as identical options due to case-insensitive matching.

Changes made:
- Modified the `onSelectSingle` function to use case-sensitive comparison

See PROD-3943.