### PR TITLE
Allow tooltip to be custom component in DataTable component

### DIFF
--- a/src/DataTable/DataTable.tsx
+++ b/src/DataTable/DataTable.tsx
@@ -294,7 +294,9 @@ export type Column = {
   sort?: (sortDirection: SortDirection) => (a: any, b: any) => number
   avatar?: (rowData: ICellTextProps["rowData"]) => string | undefined
   link?: (rowData: ICellTextProps["rowData"]) => string | (() => void) | undefined
-  tooltip?: ((rowData: ICellTextProps["rowData"]) => ReactElement<AlignProps> | string | undefined) | boolean
+  tooltip?:
+    | ((rowData: ICellTextProps["rowData"]) => ReactElement<AlignProps> | string | undefined | ReactNode)
+    | boolean
   isEditable?: boolean
   progressIndicator?: {
     type: "bar" | "circle"


### PR DESCRIPTION
Example:
![image](https://github.com/user-attachments/assets/a1556419-c27a-4600-835e-b0dea668cb2e)
