### PR TITLE
Allow custom ids to InputText components. For DataTable, give each ce…

### DIFF
--- a/src/DataTable/DataTable.tsx
+++ b/src/DataTable/DataTable.tsx
@@ -1467,6 +1467,9 @@ export const DataTable = (p: DataTableProps) => {
                       cell: {
                         elementAttributes: cellElementAttributes => {
                           const column = cellElementAttributes.column as Column
+                          const id = cellElementAttributes?.rowData?.id
+                            ? `cell-${column.key}-${cellElementAttributes?.rowData?.id}`
+                            : null
                           const classNames: string[] = []
 
                           if (p.fixedKeyField === column.key) {
@@ -1509,6 +1512,7 @@ export const DataTable = (p: DataTableProps) => {
                           }
 
                           return {
+                            id: id,
                             className: classNames.join(" "),
 
                             style: {

--- a/src/InputText/InputTextDate.tsx
+++ b/src/InputText/InputTextDate.tsx
@@ -4,6 +4,7 @@ import { Color } from "@new/Color"
 
 export type InputTextDateProps = Pick<
   InputTextProps,
+  | "id"
   | "size"
   | "width"
   | "label"
@@ -44,6 +45,7 @@ export const InputTextDate = forwardRef<HTMLInputElement, InputTextDateProps>((p
       dateMin={p.min}
       dateMax={p.max}
       data-playwright-testid={p["data-playwright-testid"]}
+      id={p.id}
     />
   )
 })

--- a/src/InputText/InputTextMultiple.tsx
+++ b/src/InputText/InputTextMultiple.tsx
@@ -4,6 +4,7 @@ import { Color } from "@new/Color"
 
 export type InputTextMultipleProps = Pick<
   InputTextProps,
+  | "id"
   | "size"
   | "width"
   | "label"
@@ -40,6 +41,7 @@ export const InputTextMultiple = forwardRef<HTMLTextAreaElement, InputTextMultip
       disabled={p.disabled ? true : undefined}
       value={p.value}
       data-playwright-testid={p["data-playwright-testid"]}
+      id={p.id}
     />
   )
 })

--- a/src/InputText/InputTextSingle.tsx
+++ b/src/InputText/InputTextSingle.tsx
@@ -4,6 +4,7 @@ import { Color } from "@new/Color"
 
 export type InputTextSingleProps = Pick<
   InputTextProps,
+  | "id"
   | "size"
   | "width"
   | "label"
@@ -44,6 +45,7 @@ export const InputTextSingle = forwardRef<HTMLInputElement, InputTextSingleProps
       disabled={p.disabled ? true : undefined}
       value={p.value}
       data-playwright-testid={p["data-playwright-testid"]}
+      id={p.id}
     />
   )
 })

--- a/src/InputText/internal/InputText.tsx
+++ b/src/InputText/internal/InputText.tsx
@@ -137,7 +137,8 @@ const Label = styled.label({
 })
 
 export const InputText = forwardRef<HTMLInputElement | HTMLTextAreaElement, InputTextProps>((p, ref) => {
-  const key = useId()
+  const generatedId = useId()
+  const key = p.id ?? generatedId
 
   const [focusCapture, setFocusCapture] = useState(false)
 


### PR DESCRIPTION
…ll an id based on column key and rowdata id (but we only set the id if rowdata.id is provided)