### PR TITLE
Feature/data table improvements

### DIFF
--- a/src/DataTable/DataTable.tsx
+++ b/src/DataTable/DataTable.tsx
@@ -1314,7 +1314,8 @@ export const DataTable = (p: DataTableProps) => {
                                 }
                                 return [color, lightness]
                               }
-
+                              const startAdornment = column?.startAdornment?.(cellTextContent.rowData)
+                              const endAdornment = column?.endAdornment?.(cellTextContent.rowData)
                               output =
                                 linkEffect && text !== TABLE_CELL_EMPTY_STRING ? (
                                   <>
@@ -1347,8 +1348,6 @@ export const DataTable = (p: DataTableProps) => {
                                     cornerRadius="small"
                                   >
                                     <>
-                                      const startAdornment = column?.startAdornment?.(cellTextContent.rowData);
-                                      const endAdornment = column?.endAdornment?.(cellTextContent.rowData);
                                       {avatarElement}
                                       {startAdornment && (
                                         <>
@@ -1364,10 +1363,10 @@ export const DataTable = (p: DataTableProps) => {
                                       >
                                         {text}
                                       </Text>
-                                      {column?.endAdornment?.(cellTextContent.rowData) && (
+                                      {endAdornment && (
                                         <>
+                                          {endAdornment}
                                           <Spacer xsmall />
-                                          {column.endAdornment(cellTextContent.rowData)}
                                         </>
                                       )}
                                     </>

--- a/src/DataTable/DataTable.tsx
+++ b/src/DataTable/DataTable.tsx
@@ -1347,10 +1347,12 @@ export const DataTable = (p: DataTableProps) => {
                                     cornerRadius="small"
                                   >
                                     <>
+                                      const startAdornment = column?.startAdornment?.(cellTextContent.rowData);
+                                      const endAdornment = column?.endAdornment?.(cellTextContent.rowData);
                                       {avatarElement}
-                                      {column?.startAdornment?.(cellTextContent.rowData) && (
+                                      {startAdornment && (
                                         <>
-                                          {column.startAdornment(cellTextContent.rowData)}
+                                          {startAdornment}
                                           <Spacer xsmall />
                                         </>
                                       )}

--- a/src/DataTable/DataTable.tsx
+++ b/src/DataTable/DataTable.tsx
@@ -253,8 +253,22 @@ const CellProgressIndicator = (cellTextProps: ICellTextProps | ICellEditorProps)
   return (
     <Stack hug horizontal>
       <Align horizontal left={type === "bar"} center={type === "circle"}>
-        <ProgressIndicator type={type} size="large" color={Color.Neutral}>
-          <ProgressIndicatorSegment width={`${value}%`} color={color} />
+        <ProgressIndicator
+          type={type}
+          size="large"
+          color={Color.Neutral}
+          labelStart={
+            typeof cellTextProps.column["startAdornment"] === "function"
+              ? cellTextProps.column["startAdornment"](cellTextProps.rowData)
+              : undefined
+          }
+          labelEnd={
+            typeof cellTextProps.column["endAdornment"] === "function"
+              ? cellTextProps.column["endAdornment"](cellTextProps.rowData)
+              : undefined
+          }
+        >
+          <ProgressIndicatorSegment width={`${value}%`} color={color} label={`${value}%`} />
         </ProgressIndicator>
       </Align>
     </Stack>
@@ -318,6 +332,8 @@ export type Column = {
   tooltip?: ((rowData: ICellTextProps["rowData"]) => ReactElement<AlignProps> | string | undefined) | boolean
   showTooltipIcon?: boolean
   isEditable?: boolean
+  endAdornment?: (rowData: ICellTextProps["rowData"]) => ReactElement<AlignProps> | string | undefined
+  startAdornment?: (rowData: ICellTextProps["rowData"]) => ReactElement<AlignProps> | string | undefined
   progressIndicator?: {
     type: "bar" | "circle"
 
@@ -456,6 +472,8 @@ export const DataTable = (p: DataTableProps) => {
       explodeWidth: column.explodeWidth,
       preventContentCollapse: column.preventContentCollapse,
       isEditable: column.isEditable,
+      endAdornment: column.endAdornment,
+      startAdornment: column.startAdornment,
     }
   })
 
@@ -1301,14 +1319,26 @@ export const DataTable = (p: DataTableProps) => {
                                 ) : (
                                   <>
                                     {avatarElement}
-                                    <Text
-                                      fill={[Color.Neutral, 700]}
-                                      small
-                                      monospace={monospace}
-                                      textOverflow={column.maxWidth !== undefined}
-                                    >
-                                      {text}
-                                    </Text>
+                                      {column?.startAdornment?.(cellTextContent.rowData) && (
+                                        <>
+                                          {column.startAdornment(cellTextContent.rowData)}
+                                          <Spacer xsmall />
+                                        </>
+                                      )}
+                                      <Text
+                                        fill={[Color.Neutral, 700]}
+                                        small
+                                        monospace={monospace}
+                                        textOverflow={column.maxWidth !== undefined}
+                                      >
+                                        {text}
+                                      </Text>
+                                      {column?.endAdornment?.(cellTextContent.rowData) && (
+                                        <>
+                                          <Spacer xsmall />
+                                          {column.endAdornment(cellTextContent.rowData)}
+                                        </>
+                                      )}
                                   </>
                                 )
                             }


### PR DESCRIPTION
Columns now support adornments:
![image](https://github.com/user-attachments/assets/e588a8d7-347d-45f9-bd10-c6463f1c86f9)
It can be an icon as well.

Also fill property:
![image](https://github.com/user-attachments/assets/d1deaa1a-2dbb-4dbd-9de3-be9fde361e44)
