### PR TITLE
Add tooltip on icon component

### DIFF
--- a/src/Icon/Icon.tsx
+++ b/src/Icon/Icon.tsx
@@ -1,6 +1,9 @@
-import { ColorWithLightness, computeColor } from "@new/Color"
+import { Color, ColorWithLightness, computeColor } from "@new/Color"
 import styled from "@emotion/styled"
 import { PlaywrightProps } from "@new/Playwright"
+import { Align } from "@new/Stack/Align"
+import { Tooltip } from "@new/Tooltip/Tooltip"
+import { Text } from "@new/Text/Text"
 
 const computeSize = (p: IconProps) => {
   let size = "0"
@@ -77,17 +80,37 @@ export type IconProps = PlaywrightProps & {
   // TODO: @cllpse: fix it
   // eslint-disable-next-line
   onClick?: any
+  tooltip?: string
 }
 
-export const Icon = (p: IconProps) => (
-  <Container
-    className="<Icon /> - material-symbols-rounded"
-    size={computeSize(p)}
-    fontVariationSettings={computeFontVariantSettings(p)}
-    _fill={p.fill}
-    onClick={p.onClick}
-    data-playwright-testid={p["data-playwright-testid"]}
-  >
-    {p.name === "blank" ? null : p.name}
-  </Container>
-)
+export const Icon = (p: IconProps) => {
+  const iconElement = (
+    <Container
+      className="<Icon /> - material-symbols-rounded"
+      size={computeSize(p)}
+      fontVariationSettings={computeFontVariantSettings(p)}
+      _fill={p.fill}
+      onClick={p.onClick}
+      data-playwright-testid={p["data-playwright-testid"]}
+    >
+      {p.name === "blank" ? null : p.name}
+    </Container>
+  )
+  return (
+    <Align horizontal hug>
+      {p.tooltip ? (
+        <Tooltip trigger={iconElement}>
+          {typeof p.tooltip === "string" ? (
+            <Text small fill={[Color.Neutral, 700]} wrap>
+              {p.tooltip}
+            </Text>
+          ) : (
+            p.tooltip
+          )}
+        </Tooltip>
+      ) : (
+        iconElement
+      )}
+    </Align>
+  )
+}

--- a/src/Tooltip/Tooltip.tsx
+++ b/src/Tooltip/Tooltip.tsx
@@ -79,7 +79,6 @@ const Trigger = styled(RadixTooltip.Trigger)<Pick<TooltipProps, "highlight">>(p 
   height: "inherit",
   justifyContent: "inherit",
   alignItems: "inherit",
-  outline: "solid 1px cyan",
   userSelect: "all",
 
   ...(p.highlight && {


### PR DESCRIPTION
Added tooltip on icons:
![image](https://github.com/user-attachments/assets/5080c6b9-562b-4871-9b17-50d78a1c3fef)


Removed outline on Tooltip component:
![image](https://github.com/user-attachments/assets/ca175c7f-6846-4966-b712-4bbc9f44683c)

I am not sure why we had it in first place I saw it sometimes appearing on table components as well. (blue outline)