### PR TITLE
PROD-4308: Allow setting name, type, and autoComplete on InputTextSingle

### DIFF
--- a/src/InputText/InputTextSingle.tsx
+++ b/src/InputText/InputTextSingle.tsx
@@ -23,15 +23,23 @@ export type InputTextSingleProps = Pick<
   | "data-playwright-testid"
 > & {
   color: Color
-  hideValue?: boolean
+  hideValue?: boolean // DEPRECATED. Use type="password" instead.
+  type?: "text" | "email" | "password"
+  autoComplete?: string
+  name?: string
 }
 
 export const InputTextSingle = forwardRef<HTMLInputElement, InputTextSingleProps>((p, ref) => {
+  // Deprecation warning for hideValue
+  if (p.hideValue && !p.type && process.env.NODE_ENV !== "production") {
+    // eslint-disable-next-line no-console
+    console.warn("InputTextSingle: 'hideValue' prop is deprecated. Use 'type=\"password\"' instead.")
+  }
+
   return (
     <InputText
       className="<InputTextSingle /> -"
-      type="text"
-      hideValue={p.hideValue}
+      type={p.type ?? (p.hideValue ? "password" : "text")}
       ref={ref}
       size={p.size}
       width={p.width}
@@ -52,6 +60,8 @@ export const InputTextSingle = forwardRef<HTMLInputElement, InputTextSingleProps
       value={p.value}
       data-playwright-testid={p["data-playwright-testid"]}
       id={p.id}
+      autoComplete={p.autoComplete}
+      name={p.name}
     />
   )
 })

--- a/src/InputText/internal/InputText.tsx
+++ b/src/InputText/internal/InputText.tsx
@@ -13,7 +13,7 @@ import { InputButtonIconTertiary } from "@new/InputButton/InputButtonIconTertiar
 import { ComponentBaseProps } from "@new/ComponentBaseProps"
 
 export type InputTextProps = ComponentBaseProps & {
-  type: "text" | "date"
+  type: "text" | "date" | "email" | "password"
 
   size: "small" | "large"
   width: "auto" | "fixed"
@@ -24,7 +24,6 @@ export type InputTextProps = ComponentBaseProps & {
 
   value: string
   onChange: (value: string) => void
-  hideValue?: boolean
 
   loading?: boolean
   disabled?: boolean
@@ -46,6 +45,9 @@ export type InputTextProps = ComponentBaseProps & {
 
   dateMin?: string
   dateMax?: string
+
+  autoComplete?: string
+  name?: string
 }
 
 const calculateWidth = (rows: InputTextProps["rows"], width: InputTextProps["width"], size: InputTextProps["size"]) => {
@@ -325,8 +327,9 @@ export const InputText = forwardRef<HTMLInputElement | HTMLTextAreaElement, Inpu
               // @ts-expect-error TypeScript can't infer the type of the `ref` prop when using as="...".
               ref={ref}
               as={p.rows === 1 ? "input" : "textarea"}
-              type={p.hideValue ? "password" : p.type}
+              type={p.type}
               id={id}
+              name={p.name}
               value={p.value}
               rows={p.rows || 1}
               color={p.error ? Color.Error : p.color}
@@ -338,7 +341,7 @@ export const InputText = forwardRef<HTMLInputElement | HTMLTextAreaElement, Inpu
               width={p.width}
               min={p.type === "date" ? p.dateMin : undefined}
               max={p.type === "date" ? p.dateMax : undefined}
-              autoComplete="one-time-code"
+              autoComplete={p.autoComplete ?? "one-time-code"}
               onChange={event => {
                 if (p.onChange) {
                   p.onChange(event?.target?.["value"])


### PR DESCRIPTION
PROD-4308: Allow setting name, type, and autoComplete on InputTextSingle to properly support login form. These changes are optional and changes nothing about the defaults.

Deprecated "hideValue" as it was just doing type="password" behind the scenes.