### PR TITLE
Fix horizontal alignment issue when cell has footer

### DIFF
--- a/src/DataTable/DataTable.tsx
+++ b/src/DataTable/DataTable.tsx
@@ -780,7 +780,7 @@ export const DataTable = <TData = any,>(p: DataTableProps<TData>) => {
                                   : null
 
                               return (
-                                <Stack hug={footerElement ? "partly" : true} horizontal>
+                                <Stack hug horizontal>
                                   {mode === "edit" && firstColumn && p.editingMode !== EditingMode.Cell ? (
                                     <Align left horizontal hug>
                                       <Icon name="drag_indicator" medium fill={[Color.Neutral, 700]} />
@@ -816,6 +816,9 @@ export const DataTable = <TData = any,>(p: DataTableProps<TData>) => {
                                       customCellRendererElement
                                     ) : (
                                       <Stack vertical hug>
+                                        {/* If there is a footer element, the content gets pushed closer to the borders of the cell. Add a tiny spacer for the cell to become larger */}
+                                        {footerElement && <Spacer tiny />}
+
                                         <Align horizontal left={!alignmentRight} right={alignmentRight}>
                                           {tooltipElement ? (
                                             <Tooltip
@@ -847,6 +850,8 @@ export const DataTable = <TData = any,>(p: DataTableProps<TData>) => {
                                             <Align horizontal left={!alignmentRight} right={alignmentRight}>
                                               {footerElement}
                                             </Align>
+
+                                            <Spacer tiny />
                                           </>
                                         )}
                                       </Stack>


### PR DESCRIPTION
Before: 
<img width="2213" height="265" alt="image" src="https://github.com/user-attachments/assets/f03320dd-acad-4955-88c6-e0bdc9009817" />
After:
<img width="1123" height="185" alt="image" src="https://github.com/user-attachments/assets/2bca26ae-9a46-49e2-9ac0-c0d6a4ce938a" />
