### PR TITLE
Fix DataTable link cell blocked by React javascript: URL precaution

### DIFF
--- a/src/DataTable/internal/OptimizedCellComponents.tsx
+++ b/src/DataTable/internal/OptimizedCellComponents.tsx
@@ -114,7 +114,13 @@ export const OptimizedCell = memo(
             {typeof linkEffect === "string" ? (
               <Link href={linkEffect}>{text}</Link>
             ) : (
-              <a href="javascript: void(0);" onClick={linkEffect}>
+              <a
+                href="#"
+                onClick={e => {
+                  e.preventDefault()
+                  linkEffect()
+                }}
+              >
                 {text}
               </a>
             )}

--- a/src/DataTable/internal/OptimizedCellComponents.tsx
+++ b/src/DataTable/internal/OptimizedCellComponents.tsx
@@ -114,6 +114,11 @@ export const OptimizedCell = memo(
             {typeof linkEffect === "string" ? (
               <Link href={linkEffect}>{text}</Link>
             ) : (
+              // Render a callback-style link as an anchor so it inherits the same
+              // underline/cursor/keyboard-focus styling as the Link case above.
+              // href="#" (+ preventDefault) is a placeholder that keeps the anchor
+              // focusable and visually styled without navigating; React 19 blocks
+              // the more common `href="javascript:void(0)"` idiom as a security risk.
               <a
                 href="#"
                 onClick={e => {


### PR DESCRIPTION
The OptimizedCell rendered `<a href="javascript: void(0);">` when a column's `link` prop returned a callback. React 19 blocks `javascript:` URLs as a security precaution, so clicking the cell threw "React has blocked a javascript: URL as a security precaution."

Switch to `href="#"` with `e.preventDefault()` in onClick — keeps browser default anchor styling (underline, cursor, keyboard focus) without triggering React's URL scheme block.