### PR TITLE
Hide DataTable pagination footer when only one page

### DIFF
--- a/src/DataTable/DataTable.tsx
+++ b/src/DataTable/DataTable.tsx
@@ -1149,7 +1149,7 @@ export const DataTable = <TData = any,>(p: DataTableProps<TData>) => {
                     <></>
                   )}
 
-                  {paginationConfig ? (
+                  {paginationConfig && paginationConfig.totalPages > 1 ? (
                     <DataTablePagination
                       pageIndex={paginationConfig.pageIndex}
                       pageSize={paginationConfig.pageSize}

--- a/src/Tooltip/Tooltip.tsx
+++ b/src/Tooltip/Tooltip.tsx
@@ -46,13 +46,7 @@ export const Tooltip = (p: TooltipProps) => {
         <RadixTooltip.Trigger style={wrapperStyle}>{p.trigger}</RadixTooltip.Trigger>
 
         <RadixTooltip.Portal>
-          <RadixTooltip.Content
-            side="bottom"
-            sideOffset={4}
-            alignOffset={4}
-            align="start"
-            style={contentStyle}
-          >
+          <RadixTooltip.Content side="bottom" sideOffset={4} alignOffset={4} align="start" style={contentStyle}>
             <Stack
               vertical
               hug={p.hug ? true : "partly"}


### PR DESCRIPTION
Per product request, paginated tables with fewer entries than one page worth (e.g., <25 with default page size) should not render the pagination footer, since navigation, page count, and page-size selector have no effect when all rows already fit on a single page.